### PR TITLE
Implement auth and RBAC for activity signup/unregister

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login with token-based auth
+- Role-based protection for sign up/unregister operations
 
 ## Getting Started
 
@@ -30,7 +31,25 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Teacher login, returns bearer token                                |
+| GET    | `/auth/me`                                                        | Validate token and return teacher session info                     |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up a student (teacher auth required)                          |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student (teacher auth required)                   |
+
+## Teacher Credentials
+
+Teacher usernames/passwords are stored in `teachers.json` for local development.
+
+Example:
+
+```json
+{
+   "mr_rivera": "teach123",
+   "ms_nguyen": "classroom456"
+}
+```
+
+Use these credentials in the header login form, then all write operations send `Authorization: Bearer <token>`.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,19 +5,35 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
+from pydantic import BaseModel
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+
+with teachers_file.open("r", encoding="utf-8") as file:
+    teachers = json.load(file)
+
+# In-memory token store for the current app process.
+active_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -88,9 +104,61 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    expected_password = teachers.get(payload.username)
+    if expected_password is None or expected_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(32)
+    active_sessions[token] = {"username": payload.username, "role": "teacher"}
+
+    return {
+        "token": token,
+        "role": "teacher",
+        "username": payload.username
+    }
+
+
+@app.get("/auth/me")
+def whoami(authorization: str | None = Header(default=None)):
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing authorization header")
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+
+    session = active_sessions.get(token)
+    if not session:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    return session
+
+
+def require_teacher(authorization: str | None):
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+
+    session = active_sessions.get(token)
+    if not session:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    if session.get("role") != "teacher":
+        raise HTTPException(status_code=403, detail="Teacher role required")
+
+    return session
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, authorization: str | None = Header(default=None)):
     """Sign up a student for an activity"""
+    require_teacher(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +179,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, authorization: str | None = Header(default=None)):
     """Unregister a student from an activity"""
+    require_teacher(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,48 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginForm = document.getElementById("login-form");
+  const logoutButton = document.getElementById("logout-button");
+  const loginButton = document.getElementById("login-button");
+  const authStatus = document.getElementById("auth-status");
+
+  let authToken = localStorage.getItem("teacherToken");
+  let currentUsername = localStorage.getItem("teacherUsername");
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUi() {
+    const isLoggedIn = Boolean(authToken);
+
+    if (isLoggedIn) {
+      authStatus.textContent = `Logged in as ${currentUsername} (teacher)`;
+      authStatus.className = "logged-in";
+      loginButton.classList.add("hidden");
+      logoutButton.classList.remove("hidden");
+    } else {
+      authStatus.textContent = "Not logged in";
+      authStatus.className = "logged-out";
+      loginButton.classList.remove("hidden");
+      logoutButton.classList.add("hidden");
+    }
+
+    signupForm.querySelectorAll("input, select, button").forEach((element) => {
+      element.disabled = !isLoggedIn;
+    });
+
+    const signupHeading = document.querySelector("#signup-container h3");
+    signupHeading.textContent = isLoggedIn
+      ? "Sign Up for an Activity"
+      : "Teacher login required to sign up students";
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -58,6 +100,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
+        button.disabled = !authToken;
+        button.title = authToken ? "Unregister student" : "Teacher login required";
         button.addEventListener("click", handleUnregister);
       });
     } catch (error) {
@@ -69,6 +113,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!authToken) {
+      showMessage("Teacher login required to unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,39 +129,81 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
 
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        authToken = result.token;
+        currentUsername = result.username;
+        localStorage.setItem("teacherToken", authToken);
+        localStorage.setItem("teacherUsername", currentUsername);
+        updateAuthUi();
+        fetchActivities();
+        showMessage("Teacher login successful.", "success");
+        loginForm.reset();
+      } else {
+        showMessage(result.detail || "Login failed.", "error");
+      }
+    } catch (error) {
+      showMessage("Login request failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", () => {
+    authToken = null;
+    currentUsername = null;
+    localStorage.removeItem("teacherToken");
+    localStorage.removeItem("teacherUsername");
+    updateAuthUi();
+    fetchActivities();
+    showMessage("Logged out.", "success");
+  });
+
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!authToken) {
+      showMessage("Teacher login required to sign up students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +215,30 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
+  updateAuthUi();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,15 @@
   </head>
   <body>
     <header>
+      <div id="auth-panel">
+        <div id="auth-status" class="logged-out">Not logged in</div>
+        <form id="login-form" autocomplete="off">
+          <input type="text" id="username" placeholder="Teacher username" required />
+          <input type="password" id="password" placeholder="Password" required />
+          <button type="submit" id="login-button">Login</button>
+          <button type="button" id="logout-button" class="hidden">Logout</button>
+        </form>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -24,6 +24,45 @@ header {
   border-radius: 5px;
 }
 
+#auth-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+#auth-status {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+#auth-status.logged-in {
+  color: #c8e6c9;
+}
+
+#auth-status.logged-out {
+  color: #ffccbc;
+}
+
+#login-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+#login-form input {
+  border: 1px solid #9fa8da;
+  border-radius: 4px;
+  padding: 7px 10px;
+  min-width: 180px;
+}
+
+#login-form button {
+  padding: 8px 12px;
+}
+
 header h1 {
   margin-bottom: 10px;
 }
@@ -123,6 +162,11 @@ section h3 {
 
 .delete-btn:hover {
   background-color: #ffebee;
+}
+
+.delete-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .participants-section p {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "mr_rivera": "teach123",
+  "ms_nguyen": "classroom456"
+}


### PR DESCRIPTION
## Summary
- add teacher login endpoint with bearer token sessions
- protect signup and unregister endpoints with teacher role checks
- add UI for teacher login/logout and disable write actions when logged out
- add local `teachers.json` credential file and docs updates

## API changes
- `POST /auth/login`
- `GET /auth/me`
- `POST /activities/{activity_name}/signup` now requires auth
- `DELETE /activities/{activity_name}/unregister` now requires auth

Closes #10